### PR TITLE
Fix calculation of JWT expiration time

### DIFF
--- a/v1/python_examples/authtoken_create.py
+++ b/v1/python_examples/authtoken_create.py
@@ -33,7 +33,7 @@ def create_api_token(key_file, exp_minutes):
         # generate jwt token
         jwt_contents = {
             'iss': client_id,
-            'exp': int(time.time() + exp_minutes*60*60)
+            'exp': int(time.time() + exp_minutes*60)
         }
         # sign & encode token with client secret
         encoded_jwt = jwt.encode(

--- a/v1/python_examples/custom_part_order.py
+++ b/v1/python_examples/custom_part_order.py
@@ -45,7 +45,7 @@ def create_api_token(key_file: str, exp_minutes: int) -> str:
     # Generate jwt token
     jwt_contents = {
         'iss': client_id,
-        'exp': int(time.time() + exp_minutes*60*60)
+        'exp': int(time.time() + exp_minutes*60)
     }
 
     # Sign & encode token with client secret


### PR DESCRIPTION
Hi,

I suspect that someone changed the argument from `exp_hours` to `exp_minutes` but forgot to update the calculation.
We want to convert `exp_minutes` to seconds when the [JWT expiration time field](https://tools.ietf.org/html/rfc7519#section-4.1.4) expects a value in seconds and [`time.time()`](https://docs.python.org/3/library/time.html#time.time) returns a value in seconds.